### PR TITLE
[TEST] [DO NOT MERGE] mocking odb._init

### DIFF
--- a/dvc_webdav/tests/test_dvc.py
+++ b/dvc_webdav/tests/test_dvc.py
@@ -7,6 +7,19 @@ from dvc.testing.remote_tests import (  # noqa, pylint: disable=unused-import
 )
 
 
+@pytest.fixture(autouse=True)
+def mocked_odb(mocker):
+    from dvc_objects.db import ObjectDB
+
+    oinit = ObjectDB._init
+
+    def init(self, *args, **kwargs):
+        if self.fs.protocol != "webdav":
+            return oinit(self, *args, **kwargs)
+
+    yield mocker.patch.object(ObjectDB, "_init", init)
+
+
 @pytest.fixture
 def remote(make_remote):
     yield make_remote(name="upstream", typ="webdav")


### PR DESCRIPTION
The Windows tests are painfully slow because they make 256 `makedirs` call on every initialization. 

I was trying to understand why that's the case for just 13 tests, and the issue is very likely from that initialization logic.

<table>
<tr>
	<td> Configuration
	<td> Before
	<td> After
<tr>
	<td> Windows + Python 3.10
	<td> 219.48s
	<td> 19.64s
<tr>
	<td> Windows + Python 3.9
	<td> 214.45s
	<td> 20.75s
<tr>
	<td> Windows + Python 3.8
	<td> 229.37s
	<td> 17.72s
</table>
