### PR TITLE
include custom auth header

### DIFF
--- a/dvc_webdav/__init__.py
+++ b/dvc_webdav/__init__.py
@@ -63,16 +63,18 @@ class WebDAVFileSystem(FileSystem):  # pylint:disable=abstract-method
     def _prepare_credentials(self, **config):
         user = config.get("user", None)
         password = config.get("password", None)
-
         headers = {}
-        token = config.get("token")
         auth = None
-        if token:
+        if token := config.get("token"):
             headers.update({"Authorization": f"Bearer {token}"})
         elif user:
             if not password and config.get("ask_password"):
                 password = ask_password(config["host"], user)
             auth = (user, password)
+        elif custom_auth_header := config.get("custom_auth_header"):
+            if not password and config.get("ask_password"):
+                password = ask_password(config["host"], custom_auth_header)
+            headers.update({custom_auth_header: password})
 
         return {"headers": headers, "auth": auth}
 


### PR DESCRIPTION
@skshetry I created a PR for the issue #19 (by @conrad-stork) in order to add the possibility of setting a custom auth header. I tried to be close to the setup in dvc-http (which already has the option) without changing the current structure of dvc-webdav. I will open a second PR for dvc, adapting the schema. I did not change any versions (of dvc-webdav / dvc) as I am not sure, how exactly the integration works. Let me know, if you need anything else and thanks a lot in advance!